### PR TITLE
Use a "small-and-often" approach to disk clean-up

### DIFF
--- a/ansible/linux/common/roles/github-actions-runner/files/disk_cleanup.sh
+++ b/ansible/linux/common/roles/github-actions-runner/files/disk_cleanup.sh
@@ -1,57 +1,84 @@
-#!/bin/bash
+#!/bin/bash -eu
+
+set -o pipefail
 
 # NOTE: This script is launched by GitHub Actions at the start of each
 # job, not cron. It is therefore guaranteed that no real build job is
 # executing, so it's safe to do things like deleting caches.
 
-# Log output of this script
-LOGFILE=/home/couchbase/disk_cleanup.log
-exec 3>&1 1>>${LOGFILE} 2>&1
+# Log to a file, so we have historical information.
+LOGFILE="${HOME}/disk_cleanup.log"
 
-# Disk free threshold check - above 80%, try cleaning things
-disk_too_full() {
-  used_percent=$(df -kh . | tail -n1 | awk '{print $5}' |sed -e 's/%//')
-  [[ $(($used_percent)) -ge 80 ]]
+# Returns the disk usage as a percentage (without the %).
+function usage() {
+	echo $(df -kh . | tail -n1 | awk '{print $5}' | sed -e 's/%//')
 }
 
-# If disk free percentage is too low, try docker prune
-if disk_too_full; then
-  echo -e "$(date) \trunning docker system prune"
-  docker system prune --force
+# Logs the given message to stdout and the logfile.
+function log() {
+	echo "$(date): $1" | tee -a ${LOGFILE}
+}
+
+# Runs the given command, displaying useful information before/after.
+function run() {
+	log "Started running \"$1\" | {\"usage\":\"$(usage)%\"}"
+
+	eval $1
+
+	log "Completed running \"$1\" | {\"usage\":\"$(usage)%\"}"
+}
+
+# Runs the given Go command, note that you do not need to provide the path to Go (e.g. clean -modcache).
+function run_go() {
+	GO="${HOME}/go/bin/go"
+
+	if [ ! -x ${GO} ]; then
+		return
+	fi
+
+	run "${GO} $1"
+}
+
+# Runs the given Bazel command, note that you do not need to provide the path to Bazel (e.g. clean --expunge)
+function run_bazel() {
+	BAZEL="${HOME}/go/bin/bazel"
+
+	if [ ! -x ${BAZEL} ]; then
+		return
+	fi
+
+	run "${BAZEL} $1"
+}
+
+# Provide verbose information that will display the start/exit in GitHub Actions.
+log "Disk cleanup starting"
+trap "log 'Disk cleanup completed'" EXIT
+
+# Go builds using '/tmp' by default and often litters these directories around.
+run "rm -rf $(ls -d /tmp/go-build*)"
+
+# Clean up installed binaries, and recursively inspect dependencies.
+run_go "clean -i -r"
+
+# Clean up old docker images.
+run "docker system prune --filter 'until=6h' --force"
+
+# Run a local Bazel clean.
+run_bazel "clean"
+
+# If we're under a given threshold, let CV continue before going nuclear and deleting everything.
+if [[ $(usage) -lt 75 ]]; then
+	exit 0
 fi
 
-# Next up, blow away Go build cache
-if disk_too_full; then
-  echo -e "$(date) \tdeleting go-build cache"
-  rm -rf ~/.cache/go-build
-fi
+# Completely remove the Go build cache.
+run "rm -rf ${HOME}/.cache/go-build"
 
-# Still bad, run docker system prune --all --volumes to clear build cache
-if disk_too_full; then
-  echo -e "$(date) \trunning docker system prune --all --volumes --force"
-  docker system prune --all --volumes --force
-fi
+# Completely remove any Go caches.
+run_go "clean -i -r -cache -testcache -modcache -fuzzcache"
 
-# Finally, the hammer - bazel clean --expunge.
-if disk_too_full; then
-  # This would be created by GHA jobs at this path
-  BZL=/home/couchbase/go/bin/bazel
-  if [ -x ${BZL} ]; then
-    echo -e "$(date) \trunning bazel clean --expunge"
-    cd /opt/gha/_work/couchbase-cloud/couchbase-cloud
+# Prune everything possible from Docker.
+run "docker system prune --all --volumes --force"
 
-    # Shut down any currently-running Bazel server (shouldn't be any)
-    ${BZL} shutdown
-
-    # Run clean - this starts a new server but shuts it down afterwards
-    ${BZL} clean --expunge
-
-    # Start a new server to cause it to re-create the "external" directories
-    ${BZL} info output_path
-
-    # Shut it down again so that the first build job will create it fresh
-    ${BZL} shutdown
-  fi
-fi
-
-echo -e "$(date) \tDisk cleanup completed."
+# Remove the Bazel cache, working tree and output files.
+run_bazel "clean --expunge"


### PR DESCRIPTION
Rather than running clean-up until we approach an 80% watermark, run clean-up using a "small-and-often" approach; given we run this prior to starting any actions - and use `bazel-remote` as a remote cache - we hope this will reduce the number of CV runs that fail due to disk usage.

```sh
A job started hook has been configured by the self-hosted runner administrator
Run '/home/couchbase/disk_cleanup.sh'
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
Error: Process completed with exit code 1.
```

Now that we're not running this script via `cron`, I've also modified the logging to output to `stdout` - as well as a logfile - so that we have some output in GitHub Actions, which is something we ran into recently.